### PR TITLE
Feat: custom encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ export interface EncoderConfig {
 	postFix: string
 	/** extension of the new file (e.g. .mp4) */
 	extension?: string
+	/** custom options. Ignores all other options */
+	custom?: string
 	/** discard streams */
 	discard?: {
 		video?: boolean

--- a/src/background/renderer.ts
+++ b/src/background/renderer.ts
@@ -73,6 +73,12 @@ export class Renderer extends EventEmitter {
 	private _getProcessArgs(step: RenderWorkstep) {
 		const args = ['-y', '-i', `"${step.input}"`]
 
+		if (step.encoderConfig.custom) {
+			args.push(step.encoderConfig.custom)
+			args.push(`"${step.output}"`)
+			return args
+		}
+
 		const discard = step.encoderConfig.discard || {}
 
 		if (discard.video) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -10,6 +10,8 @@ export interface EncoderConfig {
 	postFix: string
 	/** extension of the new file (e.g. .mp4) */
 	extension?: string
+	/** custom options. Ignores all other options */
+	custom?: string
 	/** discard streams */
 	discard?: {
 		video?: boolean


### PR DESCRIPTION
Added custom encoding option, assumes you know what you're doing!
Remember to escape quotation marks in the custom string (`\"`)

Example overlaying text:
````json
"encoders": [
	{
		"postFix": "_custom-text-overlay",
		"custom": "-vf drawtext=\"fontfile=/Windows/Fonts/arial.ttf: text='Custom text overlay': fontcolor=white: fontsize=120: box=1: boxcolor=black: boxborderw=20: x=(w-text_w)/2: y=(h-text_h)/1.4\"",
	}
]
````